### PR TITLE
Include the default run configuration for IntelliJ

### DIFF
--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Main" type="Application" factoryName="Application" nameIsGenerated="true">
+    <option name="MAIN_CLASS_NAME" value="uorocketry.basestation.Main" />
+    <module name="RocketGroundStation2020.main" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="uorocketry.basestation.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
This should allow IntelliJ to automatically add a run configuration without the user doing anything.